### PR TITLE
[FIX] Inactive Pagination Element Highlight Issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-rails-pagination",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "React Component for adding Pagination support to Rails or any other MVC Framework",
   "main": "src/index.js",
   "module": "dist/index.esm.js",

--- a/src/Pagination.jsx
+++ b/src/Pagination.jsx
@@ -72,10 +72,10 @@ class Pagination extends React.Component {
     }
 
     return (
-      <li key={index} className={number === page ? 'active' : ''}>
+      <li key={index} className={number === page ? 'active' : 'inactive'}>
         <a
           href={pagePath}
-          className={`${canClick ? null : 'disabled'} ${displayName === '...' ? 'separator' : ''}`}
+          className={`${canClick ? '' : 'disabled'} ${displayName === '...' ? 'separator' : ''}`}
           onClick={(e) => this.changePage(e, pagePath, pageNumber)}
         >
           {displayName}

--- a/src/_themes.scss
+++ b/src/_themes.scss
@@ -6,16 +6,14 @@
   border: 1px solid $blue-hover; //#ddd
 }
 
-.rails-pagination-primary>li>a:hover,
-.rails-pagination-primary>li>a:focus {
+.rails-pagination-primary>li>a:hover {
   color: $white;//#23527c;
   background-color: $blue-hover;//#eee;
   border-color: $blue-hover;//#ddd;
 }
 
 .rails-pagination-primary>.active>a,
-.rails-pagination-primary>.active>a:hover,
-.rails-pagination-primary>.active>a:focus {
+.rails-pagination-primary>.active>a:hover {
   color: $white;//#fff;
   background-color: $blue-hover;//#337ab7;
   border-color: $blue-hover;//#337ab7;
@@ -40,16 +38,14 @@
   border: 1px solid $primary; //#ddd
 }
 
-.rails-pagination-outline-primary>li>a:hover,
-.rails-pagination-outline-primary>li>a:focus {
+.rails-pagination-outline-primary>li>a:hover {
   color: $white;//#23527c;
   background-color: $primary;//#eee;
   border-color: $primary;//#ddd;
 }
 
 .rails-pagination-outline-primary>.active>a,
-.rails-pagination-outline-primary>.active>a:hover,
-.rails-pagination-outline-primary>.active>a:focus {
+.rails-pagination-outline-primary>.active>a:hover {
   z-index:2;
   color: $white;//#fff;
   cursor:default;
@@ -77,16 +73,14 @@
   border: 1px solid $gray-dark; //#ddd
 }
 
-.rails-pagination-secondary>li>a:hover,
-.rails-pagination-secondary>li>a:focus {
+.rails-pagination-secondary>li>a:hover {
   color: $white;//#23527c;
   background-color: $gray-dark;//#eee;
   border-color: $gray-dark;//#ddd;
 }
 
 .rails-pagination-secondary>.active>a,
-.rails-pagination-secondary>.active>a:hover,
-.rails-pagination-secondary>.active>a:focus {
+.rails-pagination-secondary>.active>a:hover {
   z-index:2;
   color: $white;//#fff;
   cursor:default;
@@ -113,16 +107,14 @@
   border: 1px solid $secondary; //#ddd
 }
 
-.rails-pagination-outline-secondary>li>a:hover,
-.rails-pagination-outline-secondary>li>a:focus {
+.rails-pagination-outline-secondary>li>a:hover {
   color: $white;//#23527c;
   background-color: $secondary;//#eee;
   border-color: $secondary;//#ddd;
 }
 
 .rails-pagination-outline-secondary>.active>a,
-.rails-pagination-outline-secondary>.active>a:hover,
-.rails-pagination-outline-secondary>.active>a:focus {
+.rails-pagination-outline-secondary>.active>a:hover {
   z-index:2;
   color: $white;//#fff;
   cursor:default;
@@ -150,16 +142,14 @@
   border: 1px solid $green-hover; //#ddd
 }
 
-.rails-pagination-success>li>a:hover,
-.rails-pagination-success>li>a:focus {
+.rails-pagination-success>li>a:hover {
   color: $white;//#23527c;
   background-color: $green-hover;//#eee;
   border-color: $green-hover;//#ddd;
 }
 
 .rails-pagination-success>.active>a,
-.rails-pagination-success>.active>a:hover,
-.rails-pagination-success>.active>a:focus {
+.rails-pagination-success>.active>a:hover {
   z-index:2;
   color: $white;//#fff;
   cursor:default;
@@ -186,16 +176,14 @@
   border: 1px solid $success; //#ddd
 }
 
-.rails-pagination-outline-success>li>a:hover,
-.rails-pagination-outline-success>li>a:focus {
+.rails-pagination-outline-success>li>a:hover {
   color: $white;//#23527c;
   background-color: $success;//#eee;
   border-color: $success;//#ddd;
 }
 
 .rails-pagination-outline-success>.active>a,
-.rails-pagination-outline-success>.active>a:hover,
-.rails-pagination-outline-success>.active>a:focus {
+.rails-pagination-outline-success>.active>a:hover {
   z-index:2;
   color: $white;//#fff;
   cursor:default;
@@ -223,16 +211,14 @@
   border: 1px solid $red-hover; //#ddd
 }
 
-.rails-pagination-danger>li>a:hover,
-.rails-pagination-danger>li>a:focus {
+.rails-pagination-danger>li>a:hover {
   color: $white;//#23527c;
   background-color: $red-hover;//#eee;
   border-color: $red-hover;//#ddd;
 }
 
 .rails-pagination-danger>.active>a,
-.rails-pagination-danger>.active>a:hover,
-.rails-pagination-danger>.active>a:focus {
+.rails-pagination-danger>.active>a:hover {
   z-index:2;
   color: $white;//#fff;
   cursor:default;
@@ -259,16 +245,14 @@
   border: 1px solid $danger; //#ddd
 }
 
-.rails-pagination-outline-danger>li>a:hover,
-.rails-pagination-outline-danger>li>a:focus {
+.rails-pagination-outline-danger>li>a:hover {
   color: $white;//#23527c;
   background-color: $danger;//#eee;
   border-color: $danger;//#ddd;
 }
 
 .rails-pagination-outline-danger>.active>a,
-.rails-pagination-outline-danger>.active>a:hover,
-.rails-pagination-outline-danger>.active>a:focus {
+.rails-pagination-outline-danger>.active>a:hover {
   z-index:2;
   color: $white;//#fff;
   cursor:default;
@@ -296,16 +280,14 @@
   border: 1px solid $yellow-hover; //#ddd
 }
 
-.rails-pagination-warning>li>a:hover,
-.rails-pagination-warning>li>a:focus {
+.rails-pagination-warning>li>a:hover {
   color: $black;//#23527c;
   background-color: $yellow-hover;//#eee;
   border-color: $yellow-hover;//#ddd;
 }
 
 .rails-pagination-warning>.active>a,
-.rails-pagination-warning>.active>a:hover,
-.rails-pagination-warning>.active>a:focus {
+.rails-pagination-warning>.active>a:hover {
   z-index:2;
   color: $black;//#fff;
   cursor:default;
@@ -332,16 +314,14 @@
   border: 1px solid $warning; //#ddd
 }
 
-.rails-pagination-outline-warning>li>a:hover,
-.rails-pagination-outline-warning>li>a:focus {
+.rails-pagination-outline-warning>li>a:hover {
   color: $white;//#23527c;
   background-color: $warning;//#eee;
   border-color: $warning;//#ddd;
 }
 
 .rails-pagination-outline-warning>.active>a,
-.rails-pagination-outline-warning>.active>a:hover,
-.rails-pagination-outline-warning>.active>a:focus {
+.rails-pagination-outline-warning>.active>a:hover {
   z-index:2;
   color: $white;//#fff;
   cursor:default;
@@ -369,16 +349,14 @@
   border: 1px solid $cyan-hover; //#ddd
 }
 
-.rails-pagination-info>li>a:hover,
-.rails-pagination-info>li>a:focus {
+.rails-pagination-info>li>a:hover {
   color: $black;//#23527c;
   background-color: $cyan-hover;//#eee;
   border-color: $cyan-hover;//#ddd;
 }
 
 .rails-pagination-info>.active>a,
-.rails-pagination-info>.active>a:hover,
-.rails-pagination-info>.active>a:focus {
+.rails-pagination-info>.active>a:hover {
   z-index:2;
   color: $black;//#fff;
   cursor:default;
@@ -405,16 +383,14 @@
   border: 1px solid $info; //#ddd
 }
 
-.rails-pagination-outline-info>li>a:hover,
-.rails-pagination-outline-info>li>a:focus {
+.rails-pagination-outline-info>li>a:hover {
   color: $white;//#23527c;
   background-color: $info;//#eee;
   border-color: $info;//#ddd;
 }
 
 .rails-pagination-outline-info>.active>a,
-.rails-pagination-outline-info>.active>a:hover,
-.rails-pagination-outline-info>.active>a:focus {
+.rails-pagination-outline-info>.active>a:hover {
   z-index:2;
   color: $white;//#fff;
   cursor:default;
@@ -434,13 +410,11 @@
   border: 1px solid $dark; //#ddd
 }
 
-.rails-pagination-outline>li>a:hover,
-.rails-pagination-outline>li>a:focus {
+.rails-pagination-outline>li>a:hover {
   border-color: $dark;//#ddd;
 }
 
 .rails-pagination-outline>.active>a,
-.rails-pagination-outline>.active>a:hover,
-.rails-pagination-outline>.active>a:focus {
+.rails-pagination-outline>.active>a:hover {
   border-color: $dark;//#337ab7;
 }

--- a/src/index.css.scss
+++ b/src/index.css.scss
@@ -37,16 +37,14 @@
   border-bottom-right-radius:4px
 }
 
-.rails-pagination>li>a:hover,
-.rails-pagination>li>a:focus {
+.rails-pagination>li>a:hover {
   color: $blue-navy;//#23527c;
   background-color: $gray-border;//#eee;
   border-color: $gray-border;//#ddd;
 }
 
 .rails-pagination>.active>a,
-.rails-pagination>.active>a:hover,
-.rails-pagination>.active>a:focus {
+.rails-pagination>.active>a:hover {
   z-index:2;
   color: $white;//#fff;
   cursor:default;
@@ -60,8 +58,7 @@
 }
 
 .rails-pagination > .disabled >a,
-.rails-pagination > .disabled >a:hover,
-.rails-pagination > .disabled >a:focus {
+.rails-pagination > .disabled >a:hover {
   color:#777;
   cursor:not-allowed;
   background-color:#fff;


### PR DESCRIPTION
Fixed issue with inactive Pagination element remaining active even after another element is active.

Issue was with the css. The element was set to be highlighted on `hover` and `focus` both states.

The difference is not apparent in situations where there is no animation, but the animation to fade out an active element to highlights this issue even more as `focus` state does not transition out unless the user clicks somewhere else in the DOM

Removed highlighting for `focus` state at the moment as it does not cause any changes in the working right now.